### PR TITLE
Fix: Align Android build configuration with RN 0.72 recommendations

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "1.8.20"
     }
     repositories {
         google()


### PR DESCRIPTION
Downgraded Android SDK versions in `android/build.gradle`:
- `compileSdkVersion` to `33` (from `35`)
- `targetSdkVersion` to `33` (from `35`)
- `buildToolsVersion` to `"33.0.0"` (from `"35.0.0"`)

Adjusted Kotlin version in `android/build.gradle`:
- `kotlinVersion` to `"1.8.20"` (from `"2.0.21"`)

These changes are intended to resolve build issues on Android for React Native 0.72.6 by using SDK and Kotlin versions that are better aligned with the framework's requirements for that version.